### PR TITLE
Compatibility with Tax Free Levels

### DIFF
--- a/src/main/java/amymialee/noenchantcap/MixinPlugin.java
+++ b/src/main/java/amymialee/noenchantcap/MixinPlugin.java
@@ -1,0 +1,50 @@
+package amymialee.noenchantcap;
+
+import net.fabricmc.loader.api.FabricLoader;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class MixinPlugin implements IMixinConfigPlugin {
+	@Override
+	public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+		if (FabricLoader.getInstance().isModLoaded("taxfreelevels")) {
+			return !mixinClassName.endsWith("NECMixin_AnvilScreenHandler2");
+		}
+
+		return true;
+	}
+
+	@Override
+	public void onLoad(String mixinPackage) {
+
+	}
+
+	@Override
+	public String getRefMapperConfig() {
+		return null;
+	}
+
+	@Override
+	public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+
+	}
+
+	@Override
+	public List<String> getMixins() {
+		return null;
+	}
+
+	@Override
+	public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+	}
+
+	@Override
+	public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+	}
+}

--- a/src/main/java/amymialee/noenchantcap/mixin/NECMixin_AnvilScreenHandler.java
+++ b/src/main/java/amymialee/noenchantcap/mixin/NECMixin_AnvilScreenHandler.java
@@ -53,27 +53,4 @@ public class NECMixin_AnvilScreenHandler {
             instance.getOrCreateNbt().putInt(REPAIR_COST_KEY, repairCost);
         }
     }
-
-    //Takes fair numbers of levels.
-    @Redirect(method = "onTakeOutput", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;addExperienceLevels(I)V"))
-    private void fairLevelCost(PlayerEntity instance, int levels) {
-        if (!NoEnchantCap.getConfig().fairLevelCost) {
-            instance.addExperienceLevels(levels);
-        } else {
-            instance.addExperience(-getLevelTotal(-levels));
-        }
-    }
-    private static int getLevelTotal(int level) {
-        int total = 0;
-        for (int i = 1; i <= level; i++) {
-            if (i >= 30) {
-                total += 112 + (i - 30) * 9;
-            } else if (i >= 15) {
-                total += 37 + (i - 15) * 5;
-            } else {
-                total += 7 + i * 2;
-            }
-        }
-        return total;
-    }
 }

--- a/src/main/java/amymialee/noenchantcap/mixin/NECMixin_AnvilScreenHandler2.java
+++ b/src/main/java/amymialee/noenchantcap/mixin/NECMixin_AnvilScreenHandler2.java
@@ -1,0 +1,39 @@
+package amymialee.noenchantcap.mixin;
+
+import amymialee.noenchantcap.NoEnchantCap;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.screen.AnvilScreenHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(AnvilScreenHandler.class)
+public class NECMixin_AnvilScreenHandler2 {
+    //Takes fair numbers of levels.
+    @Redirect(method = "onTakeOutput", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;addExperienceLevels(I)V"))
+    private void fairLevelCost(PlayerEntity instance, int levels) {
+        if (!NoEnchantCap.getConfig().fairLevelCost) {
+            instance.addExperienceLevels(levels);
+        } else {
+            instance.addExperience(-getLevelTotal(-levels));
+        }
+    }
+
+    private static int getLevelTotal(int level) {
+        int total = 0;
+        for (int i = 1; i <= level; i++) {
+            if (i >= 30) {
+                total += 112 + (i - 30) * 9;
+            } else if (i >= 15) {
+                total += 37 + (i - 15) * 5;
+            } else {
+                total += 7 + i * 2;
+            }
+        }
+        return total;
+    }
+}

--- a/src/main/resources/noenchantcap.mixins.json
+++ b/src/main/resources/noenchantcap.mixins.json
@@ -6,11 +6,13 @@
   "mixins": [
     "NECMixin_AnvilScreen",
     "NECMixin_AnvilScreenHandler",
+    "NECMixin_AnvilScreenHandler2",
     "NECMixin_EnchantCommand",
     "NECMixin_Enchantment",
     "NECMixin_EnchantmentHelper",
     "NECMixin_ItemStack"
   ],
+  "plugin": "amymialee.noenchantcap.MixinPlugin",
   "injectors": {
     "defaultRequire": 1
   }


### PR DESCRIPTION
Closes #13.

I went the "split the mixin and don't load the `@Redirect` when Tax Free Levels is detected" route.